### PR TITLE
Add basic security utilities and tests

### DIFF
--- a/omndx/security/adult_content_filter.py
+++ b/omndx/security/adult_content_filter.py
@@ -1,0 +1,43 @@
+"""Heuristic based adult content filtering.
+
+The :class:`AdultContentFilter` class provides a very small text based filter
+that checks input for a list of blocked keywords.  The intent is to allow test
+scenarios to easily flag obviously inappropriate content without relying on
+heavy machine learning models.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Set
+
+
+@dataclass
+class AdultContentFilter:
+    """Simple keyword driven content filter."""
+
+    blocked_keywords: Set[str] = field(
+        default_factory=lambda: {
+            "porn",
+            "xxx",
+            "sex",
+            "nude",
+        }
+    )
+
+    def is_safe(self, text: str) -> bool:
+        """Return ``True`` if *text* does not contain blocked terms."""
+
+        lowered = text.lower()
+        return not any(word in lowered for word in self.blocked_keywords)
+
+    def filter(self, items: Iterable[str]) -> Iterable[str]:
+        """Yield only items that pass :meth:`is_safe`."""
+
+        for item in items:
+            if self.is_safe(item):
+                yield item
+
+
+__all__ = ["AdultContentFilter"]
+

--- a/omndx/security/encryption_utils.py
+++ b/omndx/security/encryption_utils.py
@@ -1,0 +1,90 @@
+"""Lightweight cryptographic helpers.
+
+This module intentionally sticks to the Python standard library so that it
+can operate in minimal environments without external dependencies.  The
+helpers provided here are **not** intended for high security scenarios but
+offer basic primitives that are sufficient for tests and demonstrations.
+
+Functions
+---------
+``generate_key``
+    Return a random key suitable for the helper functions.
+``encrypt`` / ``decrypt``
+    Symmetric XOR based transformation of byte strings.
+``hash_data`` / ``verify_hash``
+    SHA-256 based hashing with a random salt and constant time verification.
+"""
+
+from __future__ import annotations
+
+import hmac
+import os
+import hashlib
+from itertools import cycle
+from typing import Tuple, Optional
+
+
+def generate_key(length: int = 32) -> bytes:
+    """Return a new random *length* byte key.
+
+    Parameters
+    ----------
+    length:
+        Size of the key in bytes.  Defaults to 32 bytes which is sufficient
+        for the simple XOR based cipher below.
+    """
+
+    return os.urandom(length)
+
+
+def encrypt(key: bytes, data: bytes) -> bytes:
+    """Encrypt *data* using *key*.
+
+    The implementation uses a repeated XOR stream which is symmetric – the
+    same function can be used for decryption as well.  While this offers only
+    very small security guarantees, it provides a deterministic transformation
+    that suffices for testing and placeholder purposes.
+    """
+
+    return bytes(b ^ k for b, k in zip(data, cycle(key)))
+
+
+def decrypt(key: bytes, token: bytes) -> bytes:
+    """Decrypt *token* using *key*.
+
+    Since the XOR operation is its own inverse this simply reuses
+    :func:`encrypt`.
+    """
+
+    return encrypt(key, token)
+
+
+def hash_data(data: bytes, salt: Optional[bytes] = None) -> Tuple[bytes, bytes]:
+    """Return a SHA-256 hash for *data* and the salt used.
+
+    A random 16 byte salt is generated when one is not provided.  The digest is
+    returned as raw bytes together with the salt so that callers can persist or
+    later verify the hash.
+    """
+
+    if salt is None:
+        salt = os.urandom(16)
+    digest = hashlib.pbkdf2_hmac("sha256", data, salt, 100_000)
+    return digest, salt
+
+
+def verify_hash(data: bytes, digest: bytes, salt: bytes) -> bool:
+    """Return ``True`` if *data* matches the given *digest*/*salt* pair."""
+
+    new_digest, _ = hash_data(data, salt)
+    return hmac.compare_digest(new_digest, digest)
+
+
+__all__ = [
+    "generate_key",
+    "encrypt",
+    "decrypt",
+    "hash_data",
+    "verify_hash",
+]
+

--- a/omndx/security/sandbox_policy.py
+++ b/omndx/security/sandbox_policy.py
@@ -1,0 +1,66 @@
+"""Simple sandbox policy helpers.
+
+The :class:`SandboxPolicy` context manager replaces a handful of built-in
+functions to prevent access to the local file system and network.  It is a
+minimal safeguard designed for testing and demonstration purposes and should
+not be considered a full security solution.
+"""
+
+from __future__ import annotations
+
+import builtins
+import os
+import socket
+from typing import Iterable, List
+
+
+class SandboxPolicy:
+    """Context manager enforcing basic sandboxing rules.
+
+    Parameters
+    ----------
+    allowed_paths:
+        Optional iterable of directory paths that remain accessible while the
+        policy is active.  Any access outside these paths results in a
+        :class:`PermissionError`.
+    """
+
+    def __init__(self, allowed_paths: Iterable[str] | None = None) -> None:
+        self.allowed_paths: List[str] = []
+        if allowed_paths:
+            for path in allowed_paths:
+                self.allowed_paths.append(os.path.abspath(path))
+
+        self._orig_open = builtins.open
+        self._orig_socket = socket.socket
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _is_allowed(self, path: str) -> bool:
+        abspath = os.path.abspath(path)
+        return any(abspath.startswith(p) for p in self.allowed_paths)
+
+    def _sandboxed_open(self, file, *args, **kwargs):  # type: ignore[override]
+        if not self._is_allowed(file):
+            raise PermissionError("File system access denied")
+        return self._orig_open(file, *args, **kwargs)
+
+    def _sandboxed_socket(self, *args, **kwargs):  # pragma: no cover - trivial
+        raise PermissionError("Network access disabled")
+
+    # ------------------------------------------------------------------
+    # Context manager protocol
+    # ------------------------------------------------------------------
+    def __enter__(self) -> "SandboxPolicy":
+        builtins.open = self._sandboxed_open
+        socket.socket = self._sandboxed_socket  # type: ignore[assignment]
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # noqa: D401 - standard CM
+        builtins.open = self._orig_open
+        socket.socket = self._orig_socket  # type: ignore[assignment]
+
+
+__all__ = ["SandboxPolicy"]
+

--- a/omndx/security/secure_config_store.py
+++ b/omndx/security/secure_config_store.py
@@ -1,0 +1,36 @@
+"""Encrypted configuration storage utilities."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from . import encryption_utils as eu
+
+
+class SecureConfigStore:
+    """Persist configuration values encrypted on disk."""
+
+    def __init__(self, path: str | Path, key: bytes) -> None:
+        self.path = Path(path)
+        self.key = key
+
+    def write(self, data: Dict[str, Any]) -> None:
+        """Encrypt and persist *data* to the configured path."""
+
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        raw = json.dumps(data).encode()
+        token = eu.encrypt(self.key, raw)
+        self.path.write_bytes(token)
+
+    def read(self) -> Dict[str, Any]:
+        """Read and decrypt data from the configured path."""
+
+        token = self.path.read_bytes()
+        raw = eu.decrypt(self.key, token)
+        return json.loads(raw.decode())
+
+
+__all__ = ["SecureConfigStore"]
+

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,61 @@
+"""Tests for security helpers."""
+
+from __future__ import annotations
+
+import os
+import socket
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure the package root is on the import path.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from omndx.security import (
+    adult_content_filter,
+    encryption_utils,
+    sandbox_policy,
+    secure_config_store,
+)
+
+
+def test_encryption_round_trip() -> None:
+    key = encryption_utils.generate_key()
+    message = b"secret message"
+    encrypted = encryption_utils.encrypt(key, message)
+    assert encrypted != message
+    decrypted = encryption_utils.decrypt(key, encrypted)
+    assert decrypted == message
+
+
+def test_hash_and_verify() -> None:
+    data = b"important"
+    digest, salt = encryption_utils.hash_data(data)
+    assert encryption_utils.verify_hash(data, digest, salt)
+    assert not encryption_utils.verify_hash(b"tampered", digest, salt)
+
+
+def test_secure_config_store_roundtrip(tmp_path: Path) -> None:
+    key = encryption_utils.generate_key()
+    store_path = tmp_path / "config.sec"
+    store = secure_config_store.SecureConfigStore(store_path, key)
+    store.write({"token": "abc"})
+    # ensure raw file does not contain plaintext
+    assert "abc" not in store_path.read_text(errors="ignore")
+    assert store.read()["token"] == "abc"
+
+
+def test_sandbox_policy_blocks_file_and_network(tmp_path: Path) -> None:
+    with sandbox_policy.SandboxPolicy():
+        with pytest.raises(PermissionError):
+            open(tmp_path / "blocked.txt", "w")
+        with pytest.raises(PermissionError):
+            socket.socket()
+
+
+def test_adult_content_filter() -> None:
+    flt = adult_content_filter.AdultContentFilter()
+    assert flt.is_safe("wholesome text")
+    assert not flt.is_safe("this contains porn references")
+


### PR DESCRIPTION
## Summary
- Implement lightweight encryption helpers with key generation, XOR-based cipher, and salted hashing with verification
- Add sandbox policy to block unauthorized file and network access
- Provide keyword-driven adult content filter and encrypted configuration store
- Introduce tests for encryption, hashing, sandbox restrictions, content filtering, and config storage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d9567e9cc8325b1697f8649520657