### PR TITLE
Add mesh network peer, routing, replication and bandwidth controls

### DIFF
--- a/omndx/mesh/bandwidth_balancer.py
+++ b/omndx/mesh/bandwidth_balancer.py
@@ -1,0 +1,42 @@
+"""Bandwidth balancing utilities for mesh peers."""
+
+from __future__ import annotations
+
+
+class BandwidthBalancer:
+    """Simple token based bandwidth balancer.
+
+    The balancer tracks the number of bytes a peer has sent.  Each instance has
+    a ``max_bandwidth`` which represents the total number of bytes that may be
+    sent until the counter is reset.  The implementation is intentionally
+    minimal and does not attempt to model time slices – tests are expected to
+    reset the balancer manually when needed.
+    """
+
+    def __init__(self, max_bandwidth: int) -> None:
+        self.max_bandwidth = max_bandwidth
+        self._used = 0
+
+    # ------------------------------------------------------------------
+    def can_send(self, size: int) -> bool:
+        """Return ``True`` if ``size`` bytes may be sent.
+
+        If sending the data would exceed the maximum bandwidth the method
+        returns ``False``.  Otherwise the internal counter is incremented and
+        ``True`` is returned.
+        """
+
+        if self._used + size > self.max_bandwidth:
+            return False
+        self._used += size
+        return True
+
+    # ------------------------------------------------------------------
+    def reset(self) -> None:
+        """Reset the used bandwidth counter."""
+
+        self._used = 0
+
+
+__all__ = ["BandwidthBalancer"]
+

--- a/omndx/mesh/file_replicator.py
+++ b/omndx/mesh/file_replicator.py
@@ -1,0 +1,61 @@
+"""Utilities for replicating files across peers.
+
+The :class:`FileReplicator` class is a deliberately small abstraction which
+allows a :class:`~omndx.mesh.mesh_peer.MeshPeer` to share byte content with other
+peers in the network.  Each peer maintains a mapping of file name to bytes in
+memory – persistence and conflict resolution are outside the scope of these
+tests.
+
+Replication is bandwidth aware; the owning peer's
+:class:`~omndx.mesh.bandwidth_balancer.BandwidthBalancer` is consulted before
+each transfer and a :class:`RuntimeError` is raised if the peer exceeds its
+budget.  For the simple scenarios in the tests this provides sufficient
+behaviour to reason about redundancy and throttling.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+
+class FileReplicator:
+    """Replicates files to other peers."""
+
+    def __init__(self, peer: "MeshPeer") -> None:
+        self.peer = peer
+        self.files: dict[str, bytes] = {}
+
+    # ------------------------------------------------------------------
+    def store_file(self, name: str, content: bytes) -> None:
+        """Store ``content`` locally under ``name``."""
+
+        self.files[name] = content
+
+    # ------------------------------------------------------------------
+    def replicate(self, name: str, content: bytes, peers: Optional[Iterable["MeshPeer"]] = None) -> None:
+        """Replicate ``content`` to ``peers``.
+
+        If ``peers`` is ``None`` the file is replicated to all discovered peers
+        except the owner itself.  The file is stored locally as well.
+        """
+
+        # Store locally first.
+        self.store_file(name, content)
+
+        from .mesh_peer import MeshPeer
+
+        targets: Iterable[MeshPeer]
+        if peers is None:
+            targets = self.peer.discover_peers().values()
+        else:
+            targets = peers
+
+        size = len(content)
+        for target in targets:
+            if not self.peer.bandwidth_balancer.can_send(size):
+                raise RuntimeError("bandwidth exceeded")
+            target.file_replicator.store_file(name, content)
+
+
+__all__ = ["FileReplicator"]
+

--- a/omndx/mesh/mesh_peer.py
+++ b/omndx/mesh/mesh_peer.py
@@ -1,0 +1,125 @@
+"""Peer management and communication utilities.
+
+This module provides the :class:`MeshPeer` class which acts as a very small
+in-memory simulation of a peer in a mesh network.  The class is intentionally
+minimal – it is not intended to be a production ready implementation of mesh
+networking.  Instead it offers enough behaviour for the unit tests in this
+repository to model peer discovery and message exchange.
+
+The design favours clarity over performance.  Peers register themselves in a
+class level registry allowing other peers to discover them.  Messages are sent
+using the accompanying :class:`~omndx.mesh.onion_router.OnionRouter` which can
+optionally forward messages through intermediate peers to provide a form of
+onion style routing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import ClassVar, Dict, Iterable, List, Optional, Tuple
+
+from .bandwidth_balancer import BandwidthBalancer
+from .file_replicator import FileReplicator
+from .onion_router import OnionRouter
+
+
+@dataclass
+class MeshPeer:
+    """Represents a single peer in the mesh network.
+
+    Parameters
+    ----------
+    peer_id:
+        Unique identifier for the peer.
+    onion_router:
+        Optional :class:`OnionRouter` instance.  If not provided a default one
+        will be created.
+    file_replicator:
+        Optional :class:`FileReplicator` instance.  If not provided a default
+        one will be created.
+    bandwidth_balancer:
+        Optional :class:`BandwidthBalancer` instance used to throttle outgoing
+        traffic.  By default a balancer with a generous limit is used.
+    """
+
+    peer_id: str
+    onion_router: OnionRouter | None = None
+    file_replicator: FileReplicator | None = None
+    bandwidth_balancer: BandwidthBalancer | None = None
+    inbox: List[Tuple[str, str]] = field(default_factory=list)
+
+    # Class level registry of peers.  It allows very small scale peer discovery
+    # for the purposes of our tests.
+    registry: ClassVar[Dict[str, "MeshPeer"]] = {}
+
+    def __post_init__(self) -> None:
+        if self.onion_router is None:
+            self.onion_router = OnionRouter(self)
+        if self.file_replicator is None:
+            self.file_replicator = FileReplicator(self)
+        if self.bandwidth_balancer is None:
+            # 1MB default budget which is ample for the tests.
+            self.bandwidth_balancer = BandwidthBalancer(max_bandwidth=1_000_000)
+
+        # Register this peer for discovery.
+        MeshPeer.registry[self.peer_id] = self
+
+    # ------------------------------------------------------------------
+    # class helpers
+    # ------------------------------------------------------------------
+    @classmethod
+    def get_peer(cls, peer_id: str) -> Optional["MeshPeer"]:
+        """Return a peer by identifier if it exists."""
+
+        return cls.registry.get(peer_id)
+
+    @classmethod
+    def clear_registry(cls) -> None:
+        """Remove all registered peers.
+
+        Useful for tests to ensure isolation between scenarios.
+        """
+
+        cls.registry.clear()
+
+    # ------------------------------------------------------------------
+    # discovery & communication API
+    # ------------------------------------------------------------------
+    def discover_peers(self) -> Dict[str, "MeshPeer"]:
+        """Return all known peers except for ``self``."""
+
+        return {pid: p for pid, p in MeshPeer.registry.items() if pid != self.peer_id}
+
+    def send_message(self, target_id: str, message: str, path: Optional[List[str]] = None) -> None:
+        """Send a message to ``target_id``.
+
+        Parameters
+        ----------
+        target_id:
+            Identifier of the receiving peer.
+        message:
+            The string message to send.
+        path:
+            Optional list of intermediate peer identifiers that the message
+            should traverse.  When provided the message will be routed through
+            these peers using onion-style routing; otherwise the message is sent
+            directly to the target.
+        """
+
+        size = len(message.encode())
+        if not self.bandwidth_balancer.can_send(size):
+            raise RuntimeError("bandwidth exceeded")
+        assert self.onion_router is not None  # for type checkers
+        self.onion_router.send_onion(target_id, message, path or [])
+
+    # ------------------------------------------------------------------
+    # inbound handlers
+    # ------------------------------------------------------------------
+    def receive_message(self, source_id: str, message: str) -> None:
+        """Store an incoming message for inspection by tests."""
+
+        self.inbox.append((source_id, message))
+
+
+__all__ = ["MeshPeer"]
+

--- a/omndx/mesh/onion_router.py
+++ b/omndx/mesh/onion_router.py
@@ -1,0 +1,66 @@
+"""Simple onion routing simulation.
+
+The real world concept of onion routing involves wrapping a message in layers
+of encryption and forwarding it through a number of intermediate peers.  Each
+peer peels away a single layer thereby revealing the address of the next hop
+until the final recipient is reached.  Implementing the cryptographic aspects
+is far beyond the scope of this repository, however a tiny subset of the
+behaviour is useful for unit tests.
+
+The :class:`OnionRouter` class provided here performs purely logical routing –
+no encryption is attempted.  A message is forwarded through a list of peer
+identifiers, and only the final peer receives the delivered message.  The
+intermediate hops do not retain the message which mirrors the anonymity aspect
+of onion routing.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+
+class OnionRouter:
+    """Light-weight onion routing helper."""
+
+    def __init__(self, peer: "MeshPeer") -> None:
+        self.peer = peer
+
+    # ------------------------------------------------------------------
+    def send_onion(self, target_id: str, message: str, path: List[str]) -> None:
+        """Send ``message`` to ``target_id`` via the supplied ``path``.
+
+        The ``path`` parameter lists the intermediate peers that should receive
+        the message before it reaches ``target_id``.  It does **not** include the
+        target itself; the router appends it automatically.  The source peer is
+        inferred from ``self.peer``.
+        """
+
+        full_path = list(path) + [target_id]
+        self._forward(full_path, message, self.peer.peer_id)
+
+    # ------------------------------------------------------------------
+    def _forward(self, remaining_path: List[str], message: str, origin: str) -> None:
+        """Forward a message to the next hop.
+
+        ``origin`` identifies the peer that originally sent the message.  This
+        value is ultimately delivered to the final recipient.
+        """
+
+        next_hop = remaining_path[0]
+        rest = remaining_path[1:]
+
+        # Import is done lazily to avoid circular import at module level.
+        from .mesh_peer import MeshPeer
+
+        peer = MeshPeer.get_peer(next_hop)
+        if peer is None:
+            raise ValueError(f"unknown peer: {next_hop}")
+
+        if rest:
+            peer.onion_router._forward(rest, message, origin)
+        else:
+            peer.receive_message(origin, message)
+
+
+__all__ = ["OnionRouter"]
+

--- a/tests/test_mesh_integration.py
+++ b/tests/test_mesh_integration.py
@@ -1,0 +1,56 @@
+"""Integration tests for the in-memory mesh network components."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Ensure the package root is on the import path for the tests executed from the
+# repository root.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pytest
+
+from omndx.mesh.bandwidth_balancer import BandwidthBalancer
+from omndx.mesh.mesh_peer import MeshPeer
+
+
+def setup_function() -> None:
+    """Clear the peer registry before each test."""
+
+    MeshPeer.clear_registry()
+
+
+def test_onion_routed_message() -> None:
+    """Messages can be routed through intermediate peers without disclosure."""
+
+    peer_a = MeshPeer("A", bandwidth_balancer=BandwidthBalancer(1024))
+    peer_b = MeshPeer("B", bandwidth_balancer=BandwidthBalancer(1024))
+    peer_c = MeshPeer("C", bandwidth_balancer=BandwidthBalancer(1024))
+
+    peer_a.send_message("B", "secret", path=["C"])  # route through C
+
+    # Only the final recipient should have the message.
+    assert peer_b.inbox == [("A", "secret")]
+    assert peer_c.inbox == []
+
+
+def test_file_replication() -> None:
+    peer_a = MeshPeer("A", bandwidth_balancer=BandwidthBalancer(1024))
+    peer_b = MeshPeer("B", bandwidth_balancer=BandwidthBalancer(1024))
+    peer_c = MeshPeer("C", bandwidth_balancer=BandwidthBalancer(1024))
+
+    data = b"payload"
+    peer_a.file_replicator.replicate("data.bin", data)
+
+    assert peer_b.file_replicator.files["data.bin"] == data
+    assert peer_c.file_replicator.files["data.bin"] == data
+
+
+def test_bandwidth_throttling() -> None:
+    peer_a = MeshPeer("A", bandwidth_balancer=BandwidthBalancer(5))
+    MeshPeer("B")  # recipient
+
+    with pytest.raises(RuntimeError):
+        peer_a.send_message("B", "too long")
+


### PR DESCRIPTION
## Summary
- implement MeshPeer class for peer discovery and messaging
- add OnionRouter, FileReplicator and BandwidthBalancer modules
- provide integration tests covering routing, replication and bandwidth limits

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d2bcb63888325adc30ec3df667341