### PR TITLE
Implement agent orchestration framework

### DIFF
--- a/omndx/core/__init__.py
+++ b/omndx/core/__init__.py
@@ -1,6 +1,16 @@
 """Core orchestration and infrastructure components."""
 
 from .instrumentation import TagLogger
+from .agent_forge import AgentForge, AgentSpec
+from .agent_router import AgentRouter
+from .orchestrator import Orchestrator
+from .task_registry import TaskRegistry
 
-__all__ = ["TagLogger"]
-
+__all__ = [
+    "TagLogger",
+    "AgentForge",
+    "AgentSpec",
+    "AgentRouter",
+    "Orchestrator",
+    "TaskRegistry",
+]

--- a/omndx/core/agent_forge.py
+++ b/omndx/core/agent_forge.py
@@ -1,0 +1,68 @@
+"""Factory for loading and instantiating agents based on configuration."""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping, MutableMapping
+
+
+@dataclass
+class AgentSpec:
+    """Specification for constructing an agent.
+
+    Parameters
+    ----------
+    path:
+        Dotted module path to the agent class (``"package.module.Class"``).
+        Alternatively a class object can be provided directly via ``cls``.
+    params:
+        Keyword arguments passed to the agent constructor.
+    cls:
+        Direct reference to the class object.  Takes precedence over ``path``.
+    """
+
+    path: str | None = None
+    params: Mapping[str, Any] | None = None
+    cls: type | None = None
+
+
+class AgentForge:
+    """Factory responsible for creating agent instances.
+
+    The forge consumes a mapping of agent names to :class:`AgentSpec`
+    definitions.  Agents are created lazily upon first request and cached for
+    subsequent retrieval.
+    """
+
+    def __init__(self, config: Mapping[str, Mapping[str, Any]]) -> None:
+        self._config: Dict[str, AgentSpec] = {
+            name: AgentSpec(**spec) for name, spec in config.items()
+        }
+        self._instances: MutableMapping[str, Any] = {}
+
+    # ------------------------------------------------------------------
+    def _load_class(self, spec: AgentSpec) -> type:
+        if spec.cls is not None:
+            return spec.cls
+        if spec.path is None:
+            raise ValueError("AgentSpec requires either 'cls' or 'path'")
+        module_path, class_name = spec.path.rsplit(".", 1)
+        module = importlib.import_module(module_path)
+        return getattr(module, class_name)
+
+    # ------------------------------------------------------------------
+    def get_agent(self, name: str) -> Any:
+        """Return an instance of the agent identified by *name*."""
+
+        if name not in self._instances:
+            spec = self._config.get(name)
+            if spec is None:
+                raise KeyError(f"Unknown agent '{name}'")
+            cls = self._load_class(spec)
+            params = dict(spec.params or {})
+            self._instances[name] = cls(**params)
+        return self._instances[name]
+
+
+__all__ = ["AgentForge", "AgentSpec"]

--- a/omndx/core/agent_router.py
+++ b/omndx/core/agent_router.py
@@ -1,0 +1,30 @@
+"""Task routing to agent instances."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from .agent_forge import AgentForge
+
+
+class AgentRouter:
+    """Router that directs tasks to agents based on task type."""
+
+    def __init__(self, forge: AgentForge, routes: Mapping[str, str]):
+        self.forge = forge
+        self.routes = dict(routes)
+
+    # ------------------------------------------------------------------
+    def route(self, task: Mapping[str, Any]) -> Any:
+        """Dispatch *task* to the appropriate agent and return the result."""
+
+        task_type = task.get("type")
+        if task_type not in self.routes:
+            raise KeyError(f"No route for task type '{task_type}'")
+        agent_name = self.routes[task_type]
+        agent = self.forge.get_agent(agent_name)
+        handler = getattr(agent, "handle")
+        return handler(task)
+
+
+__all__ = ["AgentRouter"]

--- a/omndx/core/orchestrator.py
+++ b/omndx/core/orchestrator.py
@@ -1,0 +1,28 @@
+"""Simple orchestration of tasks across agents."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .agent_router import AgentRouter
+from .task_registry import TaskRegistry
+
+
+class Orchestrator:
+    """Coordinates task execution via a router and registry."""
+
+    def __init__(self, router: AgentRouter, registry: TaskRegistry):
+        self.router = router
+        self.registry = registry
+
+    # ------------------------------------------------------------------
+    def run(self) -> Dict[int, Any]:
+        """Execute all tasks in the registry and return results."""
+
+        results: Dict[int, Any] = {}
+        for task_id, task in self.registry.all().items():
+            results[task_id] = self.router.route(task)
+        return results
+
+
+__all__ = ["Orchestrator"]

--- a/omndx/core/task_registry.py
+++ b/omndx/core/task_registry.py
@@ -1,0 +1,48 @@
+"""In-memory task metadata registry."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class TaskRegistry:
+    """Simple registry exposing CRUD operations for task metadata."""
+
+    def __init__(self) -> None:
+        self._tasks: Dict[int, Dict[str, Any]] = {}
+        self._counter = 0
+
+    # ------------------------------------------------------------------
+    def create(self, metadata: Dict[str, Any]) -> int:
+        """Store *metadata* and return a new task identifier."""
+
+        self._counter += 1
+        self._tasks[self._counter] = dict(metadata)
+        return self._counter
+
+    # ------------------------------------------------------------------
+    def read(self, task_id: int) -> Dict[str, Any]:
+        """Return metadata for *task_id*."""
+
+        return dict(self._tasks[task_id])
+
+    # ------------------------------------------------------------------
+    def update(self, task_id: int, metadata: Dict[str, Any]) -> None:
+        """Update *task_id* with new *metadata*."""
+
+        self._tasks[task_id].update(metadata)
+
+    # ------------------------------------------------------------------
+    def delete(self, task_id: int) -> None:
+        """Remove *task_id* from the registry."""
+
+        del self._tasks[task_id]
+
+    # ------------------------------------------------------------------
+    def all(self) -> Dict[int, Dict[str, Any]]:
+        """Return a mapping of all registered tasks."""
+
+        return dict(self._tasks)
+
+
+__all__ = ["TaskRegistry"]

--- a/tests/test_agent_flow.py
+++ b/tests/test_agent_flow.py
@@ -1,0 +1,87 @@
+"""Tests for agent creation, routing and orchestration."""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any, Dict
+
+# Ensure package root on path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from omndx.core import AgentForge, AgentRouter, Orchestrator, TaskRegistry
+
+
+class EchoAgent:
+    """Agent that echoes a payload with a prefix."""
+
+    def __init__(self, prefix: str = "") -> None:
+        self.prefix = prefix
+
+    def handle(self, task: Dict[str, Any]) -> str:
+        return f"{self.prefix}{task['payload']}"
+
+
+class MultiplyAgent:
+    """Agent that multiplies a numeric payload."""
+
+    def __init__(self, factor: int) -> None:
+        self.factor = factor
+
+    def handle(self, task: Dict[str, Any]) -> int:
+        return task["payload"] * self.factor
+
+
+def _agent_path(cls: type) -> str:
+    return f"{cls.__module__}.{cls.__name__}"
+
+
+def test_agent_forge_creates_instances() -> None:
+    config = {
+        "echo": {"path": _agent_path(EchoAgent), "params": {"prefix": "hi:"}},
+    }
+    forge = AgentForge(config)
+    agent = forge.get_agent("echo")
+    assert agent.handle({"payload": "there"}) == "hi:there"
+
+
+def test_agent_router_routes_to_correct_agent() -> None:
+    config = {
+        "echo": {"path": _agent_path(EchoAgent), "params": {"prefix": ""}},
+        "mul": {"path": _agent_path(MultiplyAgent), "params": {"factor": 2}},
+    }
+    forge = AgentForge(config)
+    router = AgentRouter(forge, {"echo": "echo", "multiply": "mul"})
+
+    assert router.route({"type": "echo", "payload": "A"}) == "A"
+    assert router.route({"type": "multiply", "payload": 5}) == 10
+
+
+def test_orchestrator_runs_tasks() -> None:
+    config = {
+        "echo": {"path": _agent_path(EchoAgent), "params": {"prefix": "!"}},
+        "mul": {"path": _agent_path(MultiplyAgent), "params": {"factor": 3}},
+    }
+    forge = AgentForge(config)
+    router = AgentRouter(forge, {"echo": "echo", "multiply": "mul"})
+    registry = TaskRegistry()
+    t1 = registry.create({"type": "echo", "payload": "x"})
+    t2 = registry.create({"type": "multiply", "payload": 4})
+
+    orchestrator = Orchestrator(router, registry)
+    results = orchestrator.run()
+
+    assert results[t1] == "!x"
+    assert results[t2] == 12
+
+
+def test_task_registry_crud_operations() -> None:
+    registry = TaskRegistry()
+    task_id = registry.create({"type": "echo", "payload": "data"})
+    assert registry.read(task_id)["payload"] == "data"
+
+    registry.update(task_id, {"payload": "new"})
+    assert registry.read(task_id)["payload"] == "new"
+
+    registry.delete(task_id)
+    assert registry.all() == {}


### PR DESCRIPTION
## Summary
- add AgentForge factory to dynamically construct agents
- route tasks to agents with AgentRouter
- orchestrate task execution via Orchestrator and TaskRegistry
- provide CRUD task registry and unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d2bbfd2088325bf23a1240b511f74