### PR TITLE
Add basic CLI, web UI, log streaming, and graph visualization

### DIFF
--- a/omndx/ui/cli_shell.py
+++ b/omndx/ui/cli_shell.py
@@ -1,0 +1,84 @@
+"""Interactive command shell for OMNDX.
+
+This module provides a small wrapper around :mod:`cmd` offering a few
+commands that exercise the :class:`~omndx.core.TagLogger`.  The shell is
+primarily intended for demonstrations and tests; it is intentionally
+minimal yet showcases command parsing, tab completion and integration
+with the core instrumentation utilities.
+"""
+
+from __future__ import annotations
+
+import cmd
+from typing import Iterable, List, Optional
+
+from ..core import TagLogger
+
+
+class CliShell(cmd.Cmd):
+    """Simple interactive shell.
+
+    Parameters
+    ----------
+    logger:
+        Optional :class:`TagLogger` instance used for recording
+        instrumentation data.  When omitted a new logger named ``"cli"``
+        is created.
+    """
+
+    intro = "OMNDX CLI. Type help or ? to list commands."
+    prompt = "(omndx) "
+
+    def __init__(self, logger: Optional[TagLogger] = None) -> None:
+        super().__init__()
+        self.logger = logger or TagLogger("cli")
+        self.started = False
+
+        # Set of available command names used for completion.
+        self._commands: List[str] = ["start", "metrics", "exit", "quit"]
+
+    # ------------------------------------------------------------------
+    # Command implementations
+    # ------------------------------------------------------------------
+    def do_start(self, arg: str) -> None:
+        """Start the (mock) orchestration layer."""
+
+        if not self.started:
+            self.logger.info("starting", tag="start")
+            self.started = True
+            print("started")
+        else:
+            print("already started")
+
+    def do_metrics(self, arg: str) -> None:
+        """Display current instrumentation metrics."""
+
+        metrics = self.logger.get_metrics()
+        print(metrics)
+
+    def do_exit(self, arg: str) -> bool:  # pragma: no cover - thin wrapper
+        """Exit the shell."""
+
+        print("bye")
+        return True
+
+    # Alias ``quit`` to ``exit``.
+    do_quit = do_exit
+
+    # ------------------------------------------------------------------
+    # Tab completion helpers
+    # ------------------------------------------------------------------
+    def completenames(self, text: str, *ignored: Iterable[str]) -> List[str]:
+        """Return command name completions for *text*."""
+
+        return [name for name in self._commands if name.startswith(text)]
+
+
+def run_shell(logger: Optional[TagLogger] = None) -> None:
+    """Launch the interactive shell."""
+
+    CliShell(logger).cmdloop()
+
+
+__all__ = ["CliShell", "run_shell"]
+

--- a/omndx/ui/graph_viz.py
+++ b/omndx/ui/graph_viz.py
@@ -1,0 +1,57 @@
+"""Render simple task graphs using Graphviz."""
+
+from __future__ import annotations
+
+from typing import Iterable, Mapping, Optional
+
+try:  # pragma: no cover - dependency optional at runtime
+    from graphviz import Digraph
+except Exception:  # pragma: no cover - fallback when graphviz missing
+    Digraph = None  # type: ignore
+
+
+def render_task_graph(graph: Mapping[str, Iterable[str]], filename: Optional[str] = None) -> str:
+    """Render *graph* as Graphviz DOT source.
+
+    Parameters
+    ----------
+    graph:
+        Mapping of node names to an iterable of child node names.
+    filename:
+        Optional path to write the generated DOT representation.  The
+        function returns the DOT source in all cases allowing callers to
+        further process or render the graph externally.
+    """
+
+    if Digraph is None:
+        # Fallback: manually compose DOT representation without relying on
+        # the ``graphviz`` package.  This keeps the function usable in
+        # minimal environments such as the unit tests.
+        lines = ["digraph G {"]
+        for src, dsts in graph.items():
+            if not dsts:
+                lines.append(f'    "{src}";')
+            for dst in dsts:
+                lines.append(f'    "{src}" -> "{dst}";')
+        lines.append("}")
+        dot_source = "\n".join(lines)
+        if filename:
+            with open(filename, "w", encoding="utf8") as fh:
+                fh.write(dot_source)
+        return dot_source
+
+    dot = Digraph()
+    for src, dsts in graph.items():
+        dot.node(src)
+        for dst in dsts:
+            dot.node(dst)
+            dot.edge(src, dst)
+
+    if filename:
+        dot.save(filename)
+
+    return dot.source
+
+
+__all__ = ["render_task_graph"]
+

--- a/omndx/ui/realtime_log_viewer.py
+++ b/omndx/ui/realtime_log_viewer.py
@@ -1,0 +1,46 @@
+"""Utilities for streaming logs to user interfaces."""
+
+from __future__ import annotations
+
+import logging
+from queue import Queue
+from typing import Iterator
+
+from ..core import TagLogger
+
+
+class _QueueHandler(logging.Handler):
+    """Small logging handler that pushes formatted records onto a queue."""
+
+    def __init__(self, queue: Queue[str]) -> None:
+        super().__init__()
+        self.queue = queue
+        self.setFormatter(logging.Formatter("%(message)s"))
+
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - thin
+        self.queue.put(self.format(record))
+
+
+class LogStreamer:
+    """Attach to a :class:`TagLogger` and yield log messages as they occur."""
+
+    def __init__(self, logger: TagLogger) -> None:
+        self._queue: Queue[str] = Queue()
+        self._handler = _QueueHandler(self._queue)
+        logger.logger.addHandler(self._handler)
+        self.logger = logger
+
+    def stream(self) -> Iterator[str]:
+        """Yield log lines as they are emitted."""
+
+        while True:
+            yield self._queue.get()
+
+    def close(self) -> None:
+        """Detach the handler from the logger."""  # pragma: no cover - trivial
+
+        self.logger.logger.removeHandler(self._handler)
+
+
+__all__ = ["LogStreamer"]
+

--- a/omndx/ui/web_interface.py
+++ b/omndx/ui/web_interface.py
@@ -1,0 +1,50 @@
+"""Lightweight web dashboard built with FastAPI."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import FastAPI
+
+from ..core import TagLogger
+
+
+def create_app(logger: Optional[TagLogger] = None) -> FastAPI:
+    """Create and configure a FastAPI application.
+
+    The application exposes a handful of endpoints that exercise the
+    :class:`TagLogger` for demonstration purposes.
+    """
+
+    logger = logger or TagLogger("web")
+    app = FastAPI()
+
+    @app.get("/ping")
+    def ping() -> dict[str, str]:  # pragma: no cover - trivial
+        return {"status": "ok"}
+
+    @app.post("/start")
+    def start() -> dict[str, bool]:
+        logger.info("start requested", tag="start")
+        return {"started": True}
+
+    @app.get("/metrics")
+    def metrics() -> dict[str, int]:
+        return logger.get_metrics()
+
+    # Expose the logger via the application state for consumers that may
+    # want direct access.
+    app.state.logger = logger
+    return app
+
+
+def run(host: str = "127.0.0.1", port: int = 8000, logger: Optional[TagLogger] = None) -> None:
+    """Run the FastAPI application using ``uvicorn``."""
+
+    import uvicorn
+
+    uvicorn.run(create_app(logger), host=host, port=port)
+
+
+__all__ = ["create_app", "run"]
+

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,0 +1,54 @@
+"""End-to-end tests for CLI and web UI components."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Ensure package root on path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from fastapi.testclient import TestClient
+
+from omndx.core import TagLogger
+from omndx.ui.cli_shell import CliShell
+from omndx.ui.web_interface import create_app
+from omndx.ui.realtime_log_viewer import LogStreamer
+from omndx.ui.graph_viz import render_task_graph
+
+
+def test_cli_basic_workflow() -> None:
+    logger = TagLogger("cli-test")
+    shell = CliShell(logger)
+    shell.onecmd("start")
+    shell.onecmd("metrics")
+    assert logger.get_metrics()["start"] == 1
+
+
+def test_web_ui_basic_workflow() -> None:
+    logger = TagLogger("web-test")
+    app = create_app(logger)
+    client = TestClient(app)
+
+    resp = client.post("/start")
+    assert resp.json()["started"] is True
+
+    resp = client.get("/metrics")
+    assert resp.json()["start"] == 1
+
+
+def test_realtime_log_viewer_streams_logs() -> None:
+    logger = TagLogger("stream-test")
+    streamer = LogStreamer(logger)
+    gen = streamer.stream()
+    logger.info("hello world")
+    msg = next(gen)
+    assert "hello world" in msg
+    streamer.close()
+
+
+def test_graph_viz_outputs_dot() -> None:
+    graph = {"a": ["b", "c"], "b": [], "c": []}
+    src = render_task_graph(graph)
+    assert "a" in src and "b" in src and "c" in src
+    assert "->" in src


### PR DESCRIPTION
## Summary
- Implement `CliShell` interactive command parser with tab completion and TagLogger metrics
- Build FastAPI web interface exposing start and metrics endpoints
- Stream TagLogger output and render task graphs with Graphviz
- Add end-to-end tests for CLI, web UI, log streaming and graph viz

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d956e07ac8325bc8ea5c8e721b0c0