### PR TITLE
Implement runtime bootstrap, metrics, watchdog, and storage layer

### DIFF
--- a/omndx/runtime/bootstrap.py
+++ b/omndx/runtime/bootstrap.py
@@ -1,0 +1,112 @@
+"""Runtime bootstrap utilities.
+
+This module initialises application configuration, logging and the
+primary :mod:`asyncio` event loop used by agents. The configuration is
+loaded from ``settings.toml`` located next to this file. Logging is
+configured using a basic stream handler honouring the ``logging.level``
+field from the configuration file.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+try:  # Python 3.11+
+    import tomllib  # type: ignore[import-not-found]
+except ModuleNotFoundError:  # pragma: no cover - fallback for older versions
+    import tomli as tomllib  # type: ignore[import-not-found]
+
+# ---------------------------------------------------------------------------
+# Configuration handling
+# ---------------------------------------------------------------------------
+DEFAULT_CONFIG_PATH = Path(__file__).with_name("settings.toml")
+
+
+def load_config(path: Path = DEFAULT_CONFIG_PATH) -> Dict[str, Any]:
+    """Load configuration from *path* if it exists.
+
+    Parameters
+    ----------
+    path:
+        The path to a TOML configuration file.
+
+    Returns
+    -------
+    dict
+        Parsed configuration or an empty dictionary when the file is
+        missing or invalid.
+    """
+
+    try:
+        with path.open("rb") as fh:
+            return tomllib.load(fh)
+    except FileNotFoundError:
+        return {}
+    except Exception:  # pragma: no cover - defensive safeguard
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# Logging setup
+# ---------------------------------------------------------------------------
+
+def init_logging(config: Dict[str, Any]) -> logging.Logger:
+    """Initialise logging according to *config* and return a logger.
+
+    The configuration may contain a ``level`` entry (e.g. ``"INFO"``).
+    """
+
+    level_name = str(config.get("level", "INFO")).upper()
+    level = getattr(logging, level_name, logging.INFO)
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+    return logging.getLogger("omndx.runtime")
+
+
+# ---------------------------------------------------------------------------
+# Event loop helpers
+# ---------------------------------------------------------------------------
+
+def create_event_loop() -> asyncio.AbstractEventLoop:
+    """Create and set the main asyncio event loop."""
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    return loop
+
+
+# ---------------------------------------------------------------------------
+# Public bootstrap API
+# ---------------------------------------------------------------------------
+
+def bootstrap(
+    config_path: Path | None = None,
+) -> Tuple[Dict[str, Any], logging.Logger, asyncio.AbstractEventLoop]:
+    """Bootstrap the runtime environment.
+
+    Parameters
+    ----------
+    config_path:
+        Optional path to a configuration file. When omitted the default
+        ``settings.toml`` next to this module is used.
+
+    Returns
+    -------
+    tuple
+        A tuple of ``(config, logger, event_loop)``.
+    """
+
+    cfg_path = Path(config_path) if config_path else DEFAULT_CONFIG_PATH
+    config = load_config(cfg_path)
+    logger = init_logging(config.get("logging", {}))
+    loop = create_event_loop()
+    logger.info("Runtime initialised")
+    return config, logger, loop
+
+
+__all__ = ["bootstrap", "create_event_loop", "init_logging", "load_config"]

--- a/omndx/runtime/metrics_collector.py
+++ b/omndx/runtime/metrics_collector.py
@@ -1,0 +1,61 @@
+"""System metrics collection utilities.
+
+The :class:`MetricsCollector` provides a minimal interface to gather
+runtime metrics such as CPU and memory usage for the current process.
+The implementation avoids external dependencies and uses :mod:`psutil`
+if available, falling back to standard library facilities.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Dict
+
+try:  # pragma: no cover - optional dependency
+    import psutil  # type: ignore[import-not-found]
+except Exception:  # pragma: no cover - psutil may not be installed
+    psutil = None  # type: ignore[assignment]
+
+
+class MetricsCollector:
+    """Collect basic CPU and memory metrics."""
+
+    def __init__(self) -> None:
+        if psutil:
+            self._process = psutil.Process(os.getpid())
+        else:  # pragma: no cover - platform specific
+            self._process = None
+
+    # ------------------------------------------------------------------
+    def _cpu_percent(self) -> float:
+        if self._process:
+            try:
+                return float(self._process.cpu_percent(interval=0.0))
+            except Exception:  # pragma: no cover - defensive safeguard
+                return 0.0
+        return 0.0
+
+    def _memory_mb(self) -> float:
+        if self._process:
+            try:
+                return float(self._process.memory_info().rss) / (1024 * 1024)
+            except Exception:  # pragma: no cover - defensive safeguard
+                return 0.0
+        try:  # pragma: no cover - fallback path
+            import resource
+
+            return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+        except Exception:
+            return 0.0
+
+    # ------------------------------------------------------------------
+    def get_metrics(self) -> Dict[str, float]:
+        """Return a snapshot of the current metrics."""
+
+        return {
+            "cpu_percent": self._cpu_percent(),
+            "memory_mb": self._memory_mb(),
+        }
+
+
+__all__ = ["MetricsCollector"]

--- a/omndx/runtime/watchdog.py
+++ b/omndx/runtime/watchdog.py
@@ -1,0 +1,48 @@
+"""Watchdog for monitoring and restarting agent tasks."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Awaitable, Callable, Dict
+
+TaskFactory = Callable[[], Awaitable[None]]
+
+
+class Watchdog:
+    """Simple watchdog that restarts failing asynchronous tasks."""
+
+    def __init__(
+        self,
+        loop: asyncio.AbstractEventLoop | None = None,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self.loop = loop or asyncio.get_event_loop()
+        self.logger = logger or logging.getLogger("omndx.watchdog")
+        self._tasks: Dict[str, TaskFactory] = {}
+
+    # ------------------------------------------------------------------
+    def add_task(self, name: str, factory: TaskFactory) -> None:
+        """Register a task *factory* under *name*."""
+
+        self._tasks[name] = factory
+
+    # ------------------------------------------------------------------
+    async def _runner(self, name: str, factory: TaskFactory) -> None:
+        while True:
+            try:
+                await factory()
+                self.logger.info("Task %s completed", name)
+                break
+            except Exception:
+                self.logger.exception("Task %s failed; restarting", name)
+
+    # ------------------------------------------------------------------
+    def start(self) -> None:
+        """Start all registered tasks under watchdog supervision."""
+
+        for name, factory in self._tasks.items():
+            self.loop.create_task(self._runner(name, factory))
+
+
+__all__ = ["Watchdog"]

--- a/omndx/storage/__init__.py
+++ b/omndx/storage/__init__.py
@@ -1,2 +1,61 @@
-"""Storage abstractions and data management components."""
+"""SQLite backed storage abstraction layer.
 
+This module provides a tiny key/value store built on top of SQLite. It
+exposes a :class:`Storage` class with simple CRUD operations and a
+:func:`connect` helper returning a ready-to-use connection.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Optional
+
+DB_PATH = Path(__file__).with_name("state_store.sqlite")
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS kv (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+"""
+
+
+def connect(db_path: Path | str = DB_PATH) -> sqlite3.Connection:
+    """Return a SQLite connection initialised with the schema."""
+
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(_SCHEMA)
+    conn.commit()
+    return conn
+
+
+class Storage:
+    """Simple key/value storage backed by SQLite."""
+
+    def __init__(self, db_path: Path | str = DB_PATH) -> None:
+        self.conn = connect(db_path)
+
+    def set(self, key: str, value: str) -> None:
+        """Insert or update *key* with *value*."""
+
+        with self.conn:
+            self.conn.execute(
+                "REPLACE INTO kv (key, value) VALUES (?, ?)", (key, value)
+            )
+
+    def get(self, key: str) -> Optional[str]:
+        """Retrieve the value for *key* or ``None`` when missing."""
+
+        cur = self.conn.execute("SELECT value FROM kv WHERE key = ?", (key,))
+        row = cur.fetchone()
+        return row[0] if row else None
+
+    def delete(self, key: str) -> None:
+        """Remove *key* from the store."""
+
+        with self.conn:
+            self.conn.execute("DELETE FROM kv WHERE key = ?", (key,))
+
+
+__all__ = ["Storage", "connect"]

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,0 +1,21 @@
+"""Tests for runtime bootstrap utilities."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Ensure package root on path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from omndx.runtime.bootstrap import bootstrap
+
+
+def test_bootstrap_creates_event_loop() -> None:
+    config, logger, loop = bootstrap()
+    try:
+        assert isinstance(config, dict)
+        assert logger.name == "omndx.runtime"
+        assert not loop.is_closed()
+    finally:
+        loop.close()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,20 @@
+"""Tests for metrics collection."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Ensure package root on path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from omndx.runtime.metrics_collector import MetricsCollector
+
+
+def test_metrics_collector_reports_values() -> None:
+    collector = MetricsCollector()
+    metrics = collector.get_metrics()
+    assert "cpu_percent" in metrics
+    assert "memory_mb" in metrics
+    assert isinstance(metrics["cpu_percent"], float)
+    assert isinstance(metrics["memory_mb"], float)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,21 @@
+"""Tests for SQLite backed storage."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# Ensure package root on path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from omndx.storage import Storage
+
+
+def test_storage_crud(tmp_path: Path) -> None:
+    store = Storage(tmp_path / "test.sqlite")
+    assert store.get("foo") is None
+    store.set("foo", "bar")
+    assert store.get("foo") == "bar"
+    store.delete("foo")
+    assert store.get("foo") is None


### PR DESCRIPTION
## Summary
- initialize runtime via configuration loading, logging setup, and main event loop bootstrap
- add metrics collector for CPU and memory usage
- include watchdog to restart failed async tasks
- provide SQLite-backed storage abstraction
- add tests for bootstrap startup, metrics reporting, and storage CRUD operations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d3c7fc1748325a0a9f55370db953b