### PR TITLE
Add SQLite metrics backend with persistent collector

### DIFF
--- a/omndx/runtime/metrics_backend.py
+++ b/omndx/runtime/metrics_backend.py
@@ -1,0 +1,144 @@
+"""SQLite backed metrics storage.
+
+This module provides a minimal persistence layer for storing metric
+increments together with the timestamp at which they were recorded.  The
+backend is intentionally lightweight – it merely appends rows to a SQLite
+database and offers a couple of convenience query helpers for tests and
+simple reporting.
+
+The storage schema is a single table named ``counters`` with the following
+columns:
+
+``name``
+    Name of the metric/counter.
+
+``value``
+    Integer value to add to the counter.  Each flush from the collector is
+    persisted as a separate row allowing for time series style analysis.
+
+``ts``
+    Unix timestamp (float) representing when the value was recorded.
+
+The class defined here is purposely small – it creates connections on demand
+and therefore is safe to use from multiple runs of the application.  The test
+suite exercises a couple of typical reporting queries which can easily be
+expanded upon by consumers of the module.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+from typing import Dict, Optional
+
+
+class MetricsBackend:
+    """Persist metric counters to a SQLite database.
+
+    Parameters
+    ----------
+    db_path:
+        Path to the SQLite database file.  The parent directory must exist
+        but the file itself will be created automatically if necessary.
+    """
+
+    def __init__(self, db_path: str | Path):
+        self.path = Path(db_path)
+        # Ensure the schema exists on initialisation so subsequent operations
+        # can assume the table is present.
+        self._ensure_schema()
+
+    # ------------------------------------------------------------------
+    # internal helpers
+    def _connect(self) -> sqlite3.Connection:
+        return sqlite3.connect(self.path)
+
+    def _ensure_schema(self) -> None:
+        with self._connect() as conn:  # type: sqlite3.Connection
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS counters (
+                    name TEXT NOT NULL,
+                    value INTEGER NOT NULL,
+                    ts REAL NOT NULL
+                )
+                """
+            )
+            conn.commit()
+
+    # ------------------------------------------------------------------
+    # public API
+    def record_counter(
+        self, name: str, value: int, timestamp: Optional[float] = None
+    ) -> None:
+        """Record ``value`` for ``name`` at ``timestamp``.
+
+        Each invocation appends a row to the ``counters`` table.  If
+        ``timestamp`` is ``None`` the current time is used.
+        """
+
+        ts = float(time.time() if timestamp is None else timestamp)
+        with self._connect() as conn:
+            conn.execute(
+                "INSERT INTO counters (name, value, ts) VALUES (?, ?, ?)",
+                (name, int(value), ts),
+            )
+            conn.commit()
+
+    def query_total(self, name: str, since: Optional[float] = None) -> int:
+        """Return the total for ``name`` optionally filtering by ``since``.
+
+        Parameters
+        ----------
+        name:
+            Metric name to query.
+        since:
+            If provided, only values with a timestamp equal to or newer than
+            ``since`` are considered.
+        """
+
+        with self._connect() as conn:
+            if since is None:
+                cur = conn.execute(
+                    "SELECT COALESCE(SUM(value), 0) FROM counters WHERE name=?",
+                    (name,),
+                )
+            else:
+                cur = conn.execute(
+                    """
+                    SELECT COALESCE(SUM(value), 0)
+                    FROM counters
+                    WHERE name=? AND ts >= ?
+                    """,
+                    (name, since),
+                )
+            (total,) = cur.fetchone()
+            return int(total or 0)
+
+    def query_all(self, since: Optional[float] = None) -> Dict[str, int]:
+        """Return totals for all counters as a ``dict``.
+
+        ``since`` behaves like :meth:`query_total`.
+        """
+
+        with self._connect() as conn:
+            if since is None:
+                cur = conn.execute(
+                    "SELECT name, SUM(value) FROM counters GROUP BY name"
+                )
+            else:
+                cur = conn.execute(
+                    """
+                    SELECT name, SUM(value)
+                    FROM counters
+                    WHERE ts >= ?
+                    GROUP BY name
+                    """,
+                    (since,),
+                )
+            return {name: int(total) for name, total in cur.fetchall()}
+
+
+__all__ = ["MetricsBackend"]
+

--- a/omndx/runtime/metrics_collector.py
+++ b/omndx/runtime/metrics_collector.py
@@ -1,0 +1,75 @@
+"""In process metrics collection utilities.
+
+The :class:`MetricsCollector` class collects counter increments in memory and
+flushes them to a persistence backend.  The backend is intentionally abstract
+and only requires a ``record_counter`` method which accepts ``name``, ``value``
+and ``timestamp`` arguments.  This mirrors the interface of
+``MetricsBackend`` defined in :mod:`metrics_backend` but allows alternative
+implementations for testing.
+
+Typical usage::
+
+    backend = MetricsBackend("/tmp/metrics.db")
+    collector = MetricsCollector(backend)
+
+    collector.increment("requests")
+    collector.increment("requests", 2)
+    collector.flush()  # persists the values to the database
+
+The ``flush`` method is explicit so callers can control when the database is
+written to.  This keeps the overhead of instrumentation low while still
+allowing the caller to persist metrics periodically or at shutdown.
+"""
+
+from __future__ import annotations
+
+import time
+from collections import Counter
+from typing import MutableMapping, Protocol
+
+
+class MetricsBackendProtocol(Protocol):
+    """Protocol describing the backend expected by :class:`MetricsCollector`."""
+
+    def record_counter(self, name: str, value: int, timestamp: float | None = None) -> None:  # pragma: no cover - protocol definition
+        ...
+
+
+class MetricsCollector:
+    """Collect and persist metric counters."""
+
+    def __init__(self, backend: MetricsBackendProtocol):
+        self._backend = backend
+        self._counters: MutableMapping[str, int] = Counter()
+
+    # ------------------------------------------------------------------
+    def increment(self, name: str, amount: int = 1) -> None:
+        """Increment ``name`` by ``amount`` in memory.
+
+        The values are not persisted until :meth:`flush` is invoked.
+        """
+
+        self._counters[name] += int(amount)
+
+    # ------------------------------------------------------------------
+    def flush(self) -> None:
+        """Write all collected counters to the backend.
+
+        After flushing the in-memory counters are cleared.  A single timestamp
+        is used for all metrics recorded in a given flush to simplify
+        aggregation downstream.
+        """
+
+        if not self._counters:
+            return
+
+        ts = time.time()
+        for name, value in list(self._counters.items()):
+            if value:
+                self._backend.record_counter(name, value, ts)
+
+        self._counters.clear()
+
+
+__all__ = ["MetricsCollector"]
+

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,58 @@
+"""Integration tests for the metrics backend and collector."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+import sys
+
+# Ensure the project root (containing the ``omndx`` package) is on ``sys.path``
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from omndx.runtime.metrics_backend import MetricsBackend
+from omndx.runtime.metrics_collector import MetricsCollector
+
+
+def test_persistence_across_runs(tmp_path: Path) -> None:
+    db = tmp_path / "metrics.db"
+
+    # First "run" of the application
+    backend1 = MetricsBackend(db)
+    collector1 = MetricsCollector(backend1)
+    collector1.increment("requests", 5)
+    collector1.flush()
+
+    # Second run should see the persisted values
+    backend2 = MetricsBackend(db)
+    assert backend2.query_total("requests") == 5
+
+    # Adding more data should accumulate
+    collector2 = MetricsCollector(backend2)
+    collector2.increment("requests", 3)
+    collector2.flush()
+
+    assert backend2.query_total("requests") == 8
+
+
+def test_reporting_queries(tmp_path: Path) -> None:
+    db = tmp_path / "metrics.db"
+    backend = MetricsBackend(db)
+    collector = MetricsCollector(backend)
+
+    collector.increment("foo", 2)
+    collector.increment("bar")
+    collector.flush()
+
+    # Basic query for all counters
+    assert backend.query_all() == {"foo": 2, "bar": 1}
+
+    # Querying with a timestamp should only include recent data
+    checkpoint = time.time()
+    collector.increment("foo", 1)
+    collector.flush()
+
+    assert backend.query_total("foo", since=checkpoint) == 1
+    assert backend.query_all(since=checkpoint) == {"foo": 1}
+


### PR DESCRIPTION
## Summary
- implement SQLite-based `MetricsBackend` for storing timestamped counter values
- add `MetricsCollector` that batches increments and flushes them to the backend
- create integration tests covering persistence across runs and query helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b676fea18832589ab0dfa8cae2921