### PR TITLE
Implement sandboxed execution with metrics and tests

### DIFF
--- a/omndx/core/sandbox_manager.py
+++ b/omndx/core/sandbox_manager.py
@@ -7,7 +7,39 @@ runtime.
 
 from __future__ import annotations
 
+import os
+import sys
+import threading
+import time
+import traceback
+from dataclasses import dataclass
 from typing import Any, Callable
+
+import multiprocessing as mp
+
+from omndx.runtime.metrics_collector import metrics
+
+
+class SandboxError(Exception):
+    """Base class for sandbox related errors."""
+
+
+class SandboxTimeout(SandboxError):
+    """Raised when a tool exceeds its allotted runtime."""
+
+
+class SandboxExecutionError(SandboxError):
+    """Raised when a tool fails during execution."""
+
+
+@dataclass
+class SandboxResult:
+    """Result returned from :meth:`SandboxManager.execute`."""
+
+    return_value: Any
+    stdout: str
+    stderr: str
+    exit_code: int
 
 
 class SandboxManager:
@@ -23,22 +55,139 @@ class SandboxManager:
     * Emit security audit events and metrics for each execution.
     """
 
-    def execute(self, tool: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    def execute(self, tool: Callable[..., Any], *args: Any, **kwargs: Any) -> SandboxResult:
         """Execute ``tool`` with the provided arguments in a sandbox.
 
-        Args:
-            tool: Callable representing the tool entrypoint.
-            *args: Positional arguments forwarded to ``tool``.
-            **kwargs: Keyword arguments forwarded to ``tool``.
+        The implementation uses a separate :mod:`multiprocessing` process to run
+        the provided callable.  Stdout and stderr are piped back to the parent
+        process for streaming and the return value is transferred through a
+        ``multiprocessing.Queue``.  Basic resource limits and a wall clock
+        timeout are supported via keyword arguments.
 
-        Returns:
-            The object returned by the tool.
+        Keyword Args
+        ------------
+        timeout: float | None
+            Maximum number of seconds the tool is allowed to run.  ``None``
+            disables the limit.
+        memory_limit: int | None
+            Optional address space limit in bytes applied to the child process.
 
-        Implementation checklist:
-
-        * Materialise the sandbox and bind required resources.
-        * Stream outputs to the observability stack while enforcing quotas.
-        * Propagate cancellation signals and ensure cleanup of resources.
-        * Translate sandbox failures into structured exceptions.
+        Returns
+        -------
+        SandboxResult
+            Object containing the callable's return value, captured stdout,
+            stderr and the process' exit code.
         """
-        raise NotImplementedError("SandboxManager.execute is not yet implemented")
+
+        timeout = kwargs.pop("timeout", None)
+        memory_limit = kwargs.pop("memory_limit", None)
+
+        start = time.perf_counter()
+        tags = {"module": "SandboxManager", "tool": getattr(tool, "__name__", str(tool))}
+
+        # Queue used to communicate result or exception information back to the
+        # parent process.
+        result_queue: mp.Queue[Any] = mp.Queue()
+
+        stdout_r, stdout_w = os.pipe()
+        stderr_r, stderr_w = os.pipe()
+
+        def _target(q: mp.Queue[Any], out_fd: int, err_fd: int) -> None:
+            """Child process wrapper."""
+
+            # Rebind stdout/stderr to the provided file descriptors.
+            os.dup2(out_fd, 1)
+            os.dup2(err_fd, 2)
+            # Re-open Python level streams so ``print`` statements honour the
+            # redirected file descriptors.  This is required when the parent
+            # process has replaced ``sys.stdout``/``sys.stderr`` (e.g. pytest's
+            # capturing).
+            sys.stdout = os.fdopen(1, "w", buffering=1)
+            sys.stderr = os.fdopen(2, "w", buffering=1)
+
+            # Apply resource limits if requested.  Failures here should not
+            # propagate to the caller; they simply result in weaker isolation.
+            if timeout is not None or memory_limit is not None:  # pragma: no branch
+                try:  # pragma: no cover - platform dependent
+                    import resource
+
+                    if timeout is not None:
+                        # CPU time limit in seconds. Ensure at least one second
+                        # to allow the process to start correctly.
+                        limit = max(1, int(timeout))
+                        resource.setrlimit(resource.RLIMIT_CPU, (limit, limit))
+                    if memory_limit is not None:
+                        resource.setrlimit(resource.RLIMIT_AS, (memory_limit, memory_limit))
+                except Exception:
+                    pass
+
+            try:
+                result = tool(*args, **kwargs)
+                q.put(("result", result))
+            except Exception as exc:  # pragma: no cover - exercised in tests
+                q.put(("error", exc, traceback.format_exc()))
+            finally:
+                os.close(out_fd)
+                os.close(err_fd)
+
+        proc = mp.Process(target=_target, args=(result_queue, stdout_w, stderr_w))
+        proc.start()
+        os.close(stdout_w)
+        os.close(stderr_w)
+
+        # Read stdout/stderr in background threads to provide streaming.
+        def _reader(fd: int, buffer: list[str], stream: Any) -> None:
+            with os.fdopen(fd, "r") as pipe:
+                for line in pipe:
+                    buffer.append(line)
+                    try:
+                        stream.write(line)
+                        stream.flush()
+                    except Exception:  # pragma: no cover - logging guard
+                        pass
+
+        stdout_buffer: list[str] = []
+        stderr_buffer: list[str] = []
+        out_thread = threading.Thread(target=_reader, args=(stdout_r, stdout_buffer, sys.stdout))
+        err_thread = threading.Thread(target=_reader, args=(stderr_r, stderr_buffer, sys.stderr))
+        out_thread.start()
+        err_thread.start()
+
+        proc.join(timeout)
+        if proc.is_alive():
+            proc.terminate()
+            proc.join()
+            metrics.record("reliability", 0, tags | {"error": "timeout"})
+            metrics.record("effectiveness", 0, tags | {"status": "timeout"})
+            metrics.record("cost", 0.0, tags)
+            metrics.record("efficiency", time.perf_counter() - start, tags)
+            raise SandboxTimeout(f"execution exceeded {timeout} seconds")
+
+        out_thread.join()
+        err_thread.join()
+
+        stdout = "".join(stdout_buffer)
+        stderr = "".join(stderr_buffer)
+        exit_code = proc.exitcode or 0
+
+        if result_queue.empty():
+            metrics.record("reliability", 0, tags | {"error": "no-result"})
+            metrics.record("effectiveness", 0, tags | {"status": "failed"})
+            metrics.record("cost", 0.0, tags)
+            metrics.record("efficiency", time.perf_counter() - start, tags)
+            raise SandboxExecutionError(f"tool exited with code {exit_code}")
+
+        kind, *payload = result_queue.get()
+        duration = time.perf_counter() - start
+        metrics.record("efficiency", duration, tags)
+        metrics.record("cost", 0.0, tags)
+
+        if kind == "result":
+            metrics.record("reliability", 1, tags | {"event": "success"})
+            metrics.record("effectiveness", 1, tags | {"status": "success"})
+            return SandboxResult(payload[0], stdout, stderr, exit_code)
+
+        exc, tb = payload
+        metrics.record("reliability", 0, tags | {"error": exc.__class__.__name__})
+        metrics.record("effectiveness", 0, tags | {"status": "failed"})
+        raise SandboxExecutionError(tb)

--- a/tests/test_sandbox_manager.py
+++ b/tests/test_sandbox_manager.py
@@ -1,0 +1,38 @@
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+# Ensure package root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from omndx.core.sandbox_manager import (
+    SandboxManager,
+    SandboxTimeout,
+)
+
+
+def sample_function() -> int:
+    print("hello from sandbox")
+    print("an error", file=sys.stderr)
+    return 42
+
+
+def test_execute_streams_output_and_return_value():
+    manager = SandboxManager()
+    result = manager.execute(sample_function, timeout=5)
+    assert result.return_value == 42
+    assert "hello from sandbox" in result.stdout
+    assert "an error" in result.stderr
+    assert result.exit_code == 0
+
+
+def slow_function():
+    time.sleep(2)
+
+
+def test_execute_timeout():
+    manager = SandboxManager()
+    with pytest.raises(SandboxTimeout):
+        manager.execute(slow_function, timeout=0.5)


### PR DESCRIPTION
## Summary
- Implement sandboxed execution using a subprocess with stdout/stderr streaming, timeouts and metrics
- Define structured exceptions and result dataclass
- Add tests covering normal execution and timeout handling

## Testing
- `pytest tests/test_sandbox_manager.py -q`
- `pytest` *(fails: ModuleNotFoundError: No module named 'chromadb')*


------
https://chatgpt.com/codex/tasks/task_e_68a17c9205288325a313f31e67bbc5f4