### PR TITLE
Add asynchronous watchdog with start/stop and tests

### DIFF
--- a/omndx/runtime/watchdog.py
+++ b/omndx/runtime/watchdog.py
@@ -1,0 +1,72 @@
+"""Asynchronous watchdog for periodic health checks.
+
+The :class:`Watchdog` class provides a tiny utility that repeatedly invokes a
+callback at a configurable interval.  It is intended for light‑weight health
+checks or periodic housekeeping tasks inside the runtime environment.  The
+callback may be either synchronous or asynchronous.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from typing import Awaitable, Callable, Optional
+
+
+Callback = Callable[[], Awaitable[None] | None]
+
+
+class Watchdog:
+    """Periodically trigger a callback on an event loop.
+
+    Args:
+        interval: Number of seconds to wait between callbacks.
+        callback: The function to invoke periodically.  If the callback returns
+            an awaitable it will be awaited before scheduling the next run.
+    """
+
+    def __init__(self, interval: float, callback: Callback) -> None:
+        self._interval = float(interval)
+        self._callback = callback
+        self._task: Optional[asyncio.Task[None]] = None
+        self._stopped = asyncio.Event()
+
+    async def _run(self) -> None:
+        """Internal task that schedules the callback."""
+
+        try:
+            while not self._stopped.is_set():
+                await asyncio.sleep(self._interval)
+                result = self._callback()
+                if inspect.isawaitable(result):
+                    await result  # type: ignore[arg-type]
+        except asyncio.CancelledError:
+            # Expected during shutdown; ignore.
+            pass
+
+    def start(self) -> None:
+        """Start invoking the callback at the configured interval."""
+
+        if self._task is not None:
+            raise RuntimeError("Watchdog already running")
+        loop = asyncio.get_running_loop()
+        self._stopped.clear()
+        self._task = loop.create_task(self._run())
+
+    async def stop(self) -> None:
+        """Cancel the watchdog and wait for the task to finish."""
+
+        if self._task is None:
+            return
+        self._stopped.set()
+        self._task.cancel()
+        try:
+            await self._task
+        except asyncio.CancelledError:
+            pass
+        finally:
+            self._task = None
+
+
+__all__ = ["Watchdog"]
+

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -1,0 +1,54 @@
+"""Tests for the :mod:`omndx.runtime.watchdog` module."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+# Ensure the package root is on the import path when tests are run directly.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from omndx.runtime.watchdog import Watchdog
+
+
+def test_watchdog_invokes_callback() -> None:
+    """The watchdog should invoke the callback periodically."""
+
+    async def run_test() -> None:
+        count = 0
+
+        async def callback() -> None:
+            nonlocal count
+            count += 1
+
+        wd = Watchdog(0.05, callback)
+        wd.start()
+        await asyncio.sleep(0.16)  # allow several invocations
+        await wd.stop()
+
+        assert count >= 2
+
+    asyncio.run(run_test())
+
+
+def test_watchdog_stop_cancels_future_calls() -> None:
+    """After ``stop`` is awaited the callback should no longer run."""
+
+    async def run_test() -> None:
+        count = 0
+
+        async def callback() -> None:
+            nonlocal count
+            count += 1
+
+        wd = Watchdog(0.05, callback)
+        wd.start()
+        await asyncio.sleep(0.11)  # at least one invocation
+        await wd.stop()
+        called = count
+        await asyncio.sleep(0.1)
+        assert count == called
+
+    asyncio.run(run_test())
+


### PR DESCRIPTION
## Summary
- implement `Watchdog` class that periodically invokes a callback
- allow configurable interval with start/stop control
- add tests verifying callback execution and cancellation

## Testing
- `pytest tests/test_watchdog.py -q`
- `pytest tests/test_instrumentation.py tests/test_llm_adapter.py tests/test_task_registry.py tests/test_core_agent.py tests/test_sandbox_manager.py tests/test_watchdog.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'chromadb')*


------
https://chatgpt.com/codex/tasks/task_e_68a181f40a2c8325920894beb414d29e