### PR TITLE
Ensure sys imported in sandbox manager tests

### DIFF
--- a/tests/test_sandbox_manager.py
+++ b/tests/test_sandbox_manager.py
@@ -1,6 +1,6 @@
 import sys
-import time
 from pathlib import Path
+import time
 
 import pytest
 


### PR DESCRIPTION
## Summary
- reorder imports in sandbox manager tests and ensure `sys` is imported at the top

## Testing
- `python -m ruff check tests/test_sandbox_manager.py`
- `pytest tests/test_sandbox_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a1f0caa2b48325ab0bed891d466050