### PR TITLE
Enable async orchestrator tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 
 [project.optional-dependencies]
 langchain = ["langchain>=0.1", "langchain-community>=0.0.20", "langchain-openai>=0.0.5"]
-dev = ["ruff", "mypy", "pytest", "pytest-cov", "coverage"]
+dev = ["ruff", "mypy", "pytest", "pytest-asyncio", "pytest-cov", "coverage"]
 
 [tool.ruff]
 line-length = 100
@@ -24,6 +24,9 @@ line-length = 100
 python_version = "3.9"
 strict = true
 ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/tests/test_orchestrator_async.py
+++ b/tests/test_orchestrator_async.py
@@ -6,7 +6,7 @@ import pathlib
 
 import pytest
 
-pytest.skip("async tests require pytest-asyncio", allow_module_level=True)
+pytest.importorskip("pytest_asyncio")
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 


### PR DESCRIPTION
## Summary
- add pytest-asyncio to dev dependencies and configure pytest for asyncio
- run orchestrator async tests when pytest-asyncio is available

## Testing
- `pytest tests/test_orchestrator_async.py`

------
https://chatgpt.com/codex/tasks/task_e_68a202ec7b9483258a11c0004049c14c